### PR TITLE
bug: return structured validation errors from backend

### DIFF
--- a/src/main/java/com/masondubelbeis/clienthubapi/dto/response/ValidationErrorResponse.java
+++ b/src/main/java/com/masondubelbeis/clienthubapi/dto/response/ValidationErrorResponse.java
@@ -1,0 +1,13 @@
+package com.masondubelbeis.clienthubapi.dto.response;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ValidationErrorResponse(
+        Instant timestamp,
+        int status,
+        String error,
+        String message,
+        String path,
+        Map<String, String> errors
+) {}

--- a/src/main/java/com/masondubelbeis/clienthubapi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/masondubelbeis/clienthubapi/exception/GlobalExceptionHandler.java
@@ -1,49 +1,42 @@
 package com.masondubelbeis.clienthubapi.exception;
 
+import com.masondubelbeis.clienthubapi.dto.response.ValidationErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ErrorResponse handleNotFound(
+    public ResponseEntity<ErrorResponse> handleNotFound(
             NotFoundException ex,
             HttpServletRequest request
     ) {
-        return new ErrorResponse(
+        ErrorResponse error = new ErrorResponse(
                 Instant.now(),
                 404,
                 "Not Found",
                 ex.getMessage(),
                 request.getRequestURI()
         );
-    }
 
-    @ExceptionHandler(Exception.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public ErrorResponse handleGeneric(
-            Exception ex,
-            HttpServletRequest request
-    ) {
-        return new ErrorResponse(
-                Instant.now(),
-                500,
-                "Internal Server Error",
-                ex.getMessage(),
-                request.getRequestURI()
-        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
     }
 
     @ExceptionHandler(BadRequestException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ResponseEntity<ErrorResponse> handleBadRequest(BadRequestException ex,
-                                                          HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handleBadRequest(
+            BadRequestException ex,
+            HttpServletRequest request
+    ) {
         ErrorResponse error = new ErrorResponse(
                 Instant.now(),
                 400,
@@ -53,5 +46,60 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ValidationErrorResponse> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpServletRequest request
+    ) {
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        });
+
+        ValidationErrorResponse error = new ValidationErrorResponse(
+                Instant.now(),
+                400,
+                "Bad Request",
+                "Validation failed",
+                request.getRequestURI(),
+                errors
+        );
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(
+            ConstraintViolationException ex,
+            HttpServletRequest request
+    ) {
+        ErrorResponse error = new ErrorResponse(
+                Instant.now(),
+                400,
+                "Bad Request",
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneric(
+            Exception ex,
+            HttpServletRequest request
+    ) {
+        ErrorResponse error = new ErrorResponse(
+                Instant.now(),
+                500,
+                "Internal Server Error",
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
     }
 }


### PR DESCRIPTION
Added a ValidationErrorResponse to return for Exception handling instead of raw backend string. 